### PR TITLE
Capture and display all exceptions in dialogue

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -19,6 +20,7 @@ import 'package:upnow/services/habit_alarm_service.dart';
 import 'package:upnow/utils/app_theme.dart';
 import 'package:upnow/utils/preferences_helper.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:upnow/utils/global_error_handler.dart';
 
 // Global navigator key for accessing Navigator from outside the widget tree
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -44,7 +46,15 @@ void main() async {
   // Initialize habit alarm service
   await HabitAlarmService.initialize();
 
-  runApp(const MyApp());
+  // Initialize global error handler before the app starts
+  GlobalErrorHandler.initialize(navigatorKey: navigatorKey);
+
+  // Wrap the app in a guarded zone to catch any uncaught errors and show dialog
+  runZonedGuarded(() {
+    runApp(const MyApp());
+  }, (Object error, StackTrace stack) {
+    GlobalErrorHandler.recordError(error, stack);
+  });
 }
 
 /// Migrates any alarms with 'default' sound path to 'alarm_sound'

--- a/lib/screens/alarm/alarm_screen.dart
+++ b/lib/screens/alarm/alarm_screen.dart
@@ -11,6 +11,7 @@ import 'package:upnow/database/hive_database.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:upnow/providers/settings_provider.dart';
+import 'package:upnow/utils/global_error_handler.dart';
 
 class AlarmScreen extends StatelessWidget {
   const AlarmScreen({Key? key}) : super(key: key);
@@ -73,8 +74,13 @@ class AlarmScreen extends StatelessWidget {
       floatingActionButton: FloatingActionButton(
         heroTag: 'alarmFab',
         onPressed: () async {
-          if (!await _checkCriticalPermissions(context)) return;
-          await Navigator.pushNamed(context, '/create_alarm');
+          try {
+            if (!await _checkCriticalPermissions(context)) return;
+            await Navigator.pushNamed(context, '/create_alarm');
+          } catch (e, s) {
+            // Ensure any navigation-related errors surface visibly
+            GlobalErrorHandler.onException(e, s);
+          }
         },
         backgroundColor: AppTheme.primaryColor,
         foregroundColor: Colors.white,

--- a/lib/screens/alarm/create_alarm_screen.dart
+++ b/lib/screens/alarm/create_alarm_screen.dart
@@ -8,6 +8,7 @@ import 'package:upnow/providers/alarm_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:intl/intl.dart';
 import 'package:upnow/providers/alarm_form_provider.dart';
+import 'package:upnow/utils/global_error_handler.dart';
 
 class CreateAlarmScreen extends StatefulWidget {
   final AlarmModel? alarm; // If null, we're creating a new alarm
@@ -482,11 +483,7 @@ class _CreateAlarmScreenState extends State<CreateAlarmScreen> {
                         });
 
                       } catch (e, stackTrace) { // Add stackTrace here
-                        print("Error playing sound preview for path: $soundPath");
-                        // Now relativePath is accessible here
-                        print("Relative path attempted: $relativePath"); 
-                        print("ERROR DETAILS: $e"); // Log the error
-                        print("STACK TRACE: $stackTrace"); // Log the full stack trace
+                        GlobalErrorHandler.onException(e, stackTrace);
                       }
                       // DO NOT pop navigator here
                       // DO NOT set the main screen state here
@@ -624,13 +621,17 @@ class _CreateAlarmScreenState extends State<CreateAlarmScreen> {
   }
 
   Future<void> _saveAlarm(BuildContext context, AlarmFormProvider form) async {
-    final alarm = form.buildOrUpdate(widget.alarm);
-    final alarmProvider = Provider.of<AlarmProvider>(context, listen: false);
-    if (widget.alarm != null) {
-      await alarmProvider.updateAlarm(alarm);
-    } else {
-      await alarmProvider.addAlarm(alarm);
+    try {
+      final alarm = form.buildOrUpdate(widget.alarm);
+      final alarmProvider = Provider.of<AlarmProvider>(context, listen: false);
+      if (widget.alarm != null) {
+        await alarmProvider.updateAlarm(alarm);
+      } else {
+        await alarmProvider.addAlarm(alarm);
+      }
+      if (mounted) Navigator.pop(context, true);
+    } catch (e, s) {
+      await GlobalErrorHandler.onException(e, s);
     }
-    if (mounted) Navigator.pop(context, true);
   }
 } 

--- a/lib/utils/global_error_handler.dart
+++ b/lib/utils/global_error_handler.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class GlobalErrorHandler {
+  static GlobalKey<NavigatorState>? _navigatorKey;
+  static bool _isDialogOpen = false;
+
+  static void initialize({required GlobalKey<NavigatorState> navigatorKey}) {
+    _navigatorKey = navigatorKey;
+
+    // Route Flutter errors into the current zone so our zone handler picks them up
+    FlutterError.onError = (FlutterErrorDetails details) {
+      Zone.current.handleUncaughtError(details.exception, details.stack ?? StackTrace.current);
+    };
+
+    // Catch errors that escape to the platform dispatcher (async, isolates)
+    PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+      _showErrorDialog(error, stack);
+      return true; // prevent default error reporting
+    };
+
+    // Customize ErrorWidget so release-mode gray screen also triggers a dialog
+    ErrorWidget.builder = (FlutterErrorDetails details) {
+      // Fire-and-forget dialog; still render a minimal widget to avoid build crashes
+      _showErrorDialog(details.exception, details.stack ?? StackTrace.current);
+      return Container(
+        color: Colors.black54,
+        alignment: Alignment.center,
+        child: const Text(
+          'Something went wrong',
+          style: TextStyle(color: Colors.white),
+          textAlign: TextAlign.center,
+        ),
+      );
+    };
+  }
+
+  static void recordError(Object error, StackTrace stack) {
+    _showErrorDialog(error, stack);
+  }
+
+  static Future<void> onException(Object error, [StackTrace? stack]) async {
+    _showErrorDialog(error, stack ?? StackTrace.current);
+  }
+
+  static void _showErrorDialog(Object error, StackTrace stack) {
+    try {
+      if (_navigatorKey?.currentState == null) {
+        // Navigator not ready; just log
+        debugPrint('GlobalErrorHandler: navigator not ready for dialog');
+        debugPrint('ERROR: $error');
+        debugPrint('STACK: $stack');
+        return;
+      }
+
+      if (_isDialogOpen) {
+        // Avoid flooding with dialogs
+        return;
+      }
+      _isDialogOpen = true;
+
+      final BuildContext? context = _navigatorKey!.currentState!.overlay?.context;
+      if (context == null) {
+        debugPrint('GlobalErrorHandler: no overlay context available');
+        debugPrint('ERROR: $error');
+        debugPrint('STACK: $stack');
+        _isDialogOpen = false;
+        return;
+      }
+
+      final String errorText = _formatErrorForDisplay(error, stack);
+
+      // Schedule after current frame to avoid setState during build
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        await showDialog<void>(
+          context: context,
+          barrierDismissible: true,
+          builder: (ctx) {
+            return AlertDialog(
+              title: const Text('Unexpected Error'),
+              content: ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 320, minWidth: 280),
+                child: Scrollbar(
+                  thumbVisibility: true,
+                  child: SingleChildScrollView(
+                    child: SelectableText(
+                      errorText,
+                      style: const TextStyle(fontSize: 12.5),
+                    ),
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () async {
+                    await Clipboard.setData(ClipboardData(text: errorText));
+                    ScaffoldMessenger.of(ctx).showSnackBar(
+                      const SnackBar(content: Text('Error copied to clipboard')),
+                    );
+                  },
+                  child: const Text('Copy'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(ctx, rootNavigator: true).pop(),
+                  child: const Text('Close'),
+                ),
+              ],
+            );
+          },
+        );
+        _isDialogOpen = false;
+      });
+    } catch (dialogError, dialogStack) {
+      // As a last resort, log to console
+      debugPrint('GlobalErrorHandler failed to present dialog: $dialogError');
+      debugPrint('Dialog STACK: $dialogStack');
+      debugPrint('Original ERROR: $error');
+      debugPrint('Original STACK: $stack');
+      _isDialogOpen = false;
+    }
+  }
+
+  static String _formatErrorForDisplay(Object error, StackTrace stack) {
+    final String timestamp = DateTime.now().toIso8601String();
+    final buffer = StringBuffer()
+      ..writeln('Time: $timestamp')
+      ..writeln('Error: $error')
+      ..writeln('')
+      ..writeln('Stack trace:')
+      ..writeln(stack.toString());
+    return buffer.toString();
+  }
+}


### PR DESCRIPTION
Implement a global error handler to display copyable dialogs for uncaught exceptions, preventing grey screens and aiding internal testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d7e9d56-6cb9-4e55-82e0-17e0438f00fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d7e9d56-6cb9-4e55-82e0-17e0438f00fb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

