### PR TITLE
Fix missing alarm form provider

### DIFF
--- a/lib/screens/alarm/create_alarm_screen.dart
+++ b/lib/screens/alarm/create_alarm_screen.dart
@@ -164,30 +164,35 @@ class _CreateAlarmScreenState extends State<CreateAlarmScreen> {
           child: Row(
             children: [
               _buildDismissOption(
+                form: form,
                 type: DismissType.math,
                 icon: Icons.calculate_outlined,
                 title: 'Math Problem',
                 color: Colors.orange,
               ),
               _buildDismissOption(
+                form: form,
                 type: DismissType.typing,
                 icon: Icons.keyboard_alt_outlined,
                 title: 'Type Text',
                 color: Colors.green,
               ),
               _buildDismissOption(
+                form: form,
                 type: DismissType.shake,
                 icon: Icons.vibration,
                 title: 'Shake Phone',
                 color: Colors.purple,
               ),
               _buildDismissOption(
+                form: form,
                 type: DismissType.memory,
                 icon: Icons.psychology_outlined,
                 title: 'Memory Game',
                 color: Colors.blue,
               ),
               _buildDismissOption(
+                form: form,
                 type: DismissType.barcode,
                 icon: Icons.qr_code_scanner,
                 title: 'Scan Barcode',
@@ -201,12 +206,12 @@ class _CreateAlarmScreenState extends State<CreateAlarmScreen> {
   }
 
   Widget _buildDismissOption({
+    required AlarmFormProvider form,
     required DismissType type,
     required IconData icon,
     required String title,
     required Color color,
   }) {
-    final form = context.read<AlarmFormProvider>();
     final isSelected = form.dismissType == type;
     final bool isComingSoon = type != DismissType.math && type != DismissType.normal;
     // Create a global key for the tooltip
@@ -387,15 +392,14 @@ class _CreateAlarmScreenState extends State<CreateAlarmScreen> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: List.generate(7, (index) {
-            return _buildDayToggle(index, dayLabels[index]);
+            return _buildDayToggle(form, index, dayLabels[index]);
           }),
         ),
       ],
     );
   }
 
-  Widget _buildDayToggle(int dayIndex, String label) {
-    final form = context.read<AlarmFormProvider>();
+  Widget _buildDayToggle(AlarmFormProvider form, int dayIndex, String label) {
     final isSelected = form.weekdays[dayIndex];
     
     return GestureDetector(


### PR DESCRIPTION
Fixes `Provider<AlarmFormProvider> not found` error by passing the form provider directly to helper methods.

The `AlarmFormProvider` was correctly provided in the widget tree, but helper methods like `_buildDismissOption` and `_buildDayToggle` were attempting to read it using the `State`'s `context`. This `context` was higher in the widget tree than where the `ChangeNotifierProvider` was defined, leading to the "Provider not found" error. By passing the `form` instance (already available from the `Consumer` widget) directly to these helper methods, we ensure they access the provider from the correct scope.

---
<a href="https://cursor.com/background-agent?bcId=bc-94bdba3c-54d4-4d52-9fd4-a941fe694b07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94bdba3c-54d4-4d52-9fd4-a941fe694b07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

