### PR TITLE
Show version and build numbers in settings

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -16,6 +16,7 @@ import 'package:upnow/screens/settings/feedback_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:upnow/providers/settings_provider.dart';
 import 'package:upnow/providers/alarm_provider.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({Key? key}) : super(key: key);
@@ -53,8 +54,9 @@ class SettingsScreen extends StatelessWidget {
                 onTap: () {
                   // Future: Show language picker
                 },
-                isLast: true,
+                isLast: false,
               ),
+              _buildAppVersionTile(),
             ],
           ),
           SizedBox(height: 32.h),
@@ -199,6 +201,35 @@ class SettingsScreen extends StatelessWidget {
     if (pickedTime != null) {
       await alarmProvider.updateMorningAlarm(pickedTime.hour, pickedTime.minute);
     }
+  }
+
+  Widget _buildAppVersionTile() {
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      builder: (context, snapshot) {
+        final String displayText;
+        if (snapshot.hasData) {
+          final info = snapshot.data!;
+          // Example: 1.0.0 (6)
+          displayText = '${info.version} (${info.buildNumber})';
+        } else {
+          displayText = '—';
+        }
+
+        return _buildSettingTile(
+          icon: Icons.info_outline,
+          title: 'App Version',
+          trailing: Text(
+            displayText,
+            style: TextStyle(
+              fontSize: 14.sp,
+              color: AppTheme.secondaryTextColor,
+            ),
+          ),
+          isLast: true,
+        );
+      },
+    );
   }
 
   Widget _buildSectionTitle(String title) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   audioplayers: ^6.0.0
   shared_preferences: ^2.2.2
   flutter_screenutil: ^5.9.0
+  package_info_plus: ^8.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Add app version and build number to the settings screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-f719b655-8c74-47be-8728-545b33c707de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f719b655-8c74-47be-8728-545b33c707de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

