### PR TITLE
Open congratulation screen from terminated state

### DIFF
--- a/android/app/src/main/kotlin/com/example/upnow/AlarmActivity.kt
+++ b/android/app/src/main/kotlin/com/example/upnow/AlarmActivity.kt
@@ -385,8 +385,21 @@ class AlarmActivity : AppCompatActivity() {
         
         Log.d(TAG, "Alarm stopped, opening congratulations screen")
         
-        // Open congratulations screen in Flutter
+        // Attempt to open congratulations screen via running Flutter instance (if available)
         MainActivity.openCongratulationsScreenStatic()
+        
+        // Also launch MainActivity with an extra so that if the app is terminated, it will start
+        // and then navigate to the congratulations screen once Flutter is ready.
+        try {
+            val mainIntent = Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                putExtra("open_congratulations", true)
+            }
+            startActivity(mainIntent)
+            Log.d(TAG, "MainActivity launched with open_congratulations flag")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to launch MainActivity for congratulations: ${e.message}")
+        }
         
         // Notify Flutter through broadcast (optional, implement if needed)
         val intent = Intent("com.example.upnow.ALARM_DISMISSED")

--- a/android/app/src/main/kotlin/com/example/upnow/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/upnow/MainActivity.kt
@@ -370,6 +370,28 @@ class MainActivity : FlutterActivity() {
     override fun onCreate(savedInstanceState: android.os.Bundle?) {
         super.onCreate(savedInstanceState)
         instance = this
+        // If launched with an instruction to open the congratulations screen, handle it.
+        handleOpenCongratulationsIntent(intent)
+    }
+    
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // Handle cases where MainActivity is already running and receives a new intent
+        handleOpenCongratulationsIntent(intent)
+    }
+
+    private fun handleOpenCongratulationsIntent(startIntent: Intent?) {
+        try {
+            if (startIntent?.getBooleanExtra("open_congratulations", false) == true) {
+                Log.d("MainActivity", "Received request via intent to open congratulations screen")
+                // Defer slightly to ensure Flutter is attached
+                window?.decorView?.post {
+                    openCongratulationsScreen()
+                }
+            }
+        } catch (e: Exception) {
+            Log.e("MainActivity", "Error handling open_congratulations intent: ${e.message}")
+        }
     }
     
     override fun onDestroy() {

--- a/lib/services/alarm_service.dart
+++ b/lib/services/alarm_service.dart
@@ -199,7 +199,10 @@ class AlarmService {
       case 'openCongratulationsScreen':
         try {
           // Navigate to congratulations screen using global navigator key
-          navigatorKey.currentState?.pushNamed('/congratulations');
+          navigatorKey.currentState?.pushNamedAndRemoveUntil(
+            '/congratulations',
+            (route) => route.isFirst || route.settings.name == '/',
+          );
           debugPrint('📱 ALARM SERVICE: Opened congratulations screen');
         } catch (e) {
           debugPrint('📱 ALARM SERVICE: Error opening congratulations screen: $e');


### PR DESCRIPTION
Ensure the congratulations screen consistently opens after solving an alarm's math, even if the app is backgrounded or terminated.

Previously, the congratulations screen would not appear if the app was terminated when the math problem was solved. This PR addresses this by having the Android `AlarmActivity` launch `MainActivity` with a specific intent flag, which `MainActivity` then processes to navigate to the congratulations screen once the Flutter engine is initialized. Additionally, the Flutter navigation now uses `pushNamedAndRemoveUntil` for a cleaner user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca4af2ae-68f2-4fb0-b04e-e8ed8b672bc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca4af2ae-68f2-4fb0-b04e-e8ed8b672bc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

